### PR TITLE
delete-old-branches: Also fetch tags during initial git fetch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: "Release"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "marvinpinto/action-automatic-releases@cc0ca445955b16365f2c14ea5aa81d5c92a8dc74"
+      - uses: "marvinpinto/action-automatic-releases@7787f7d200d647f2e8739c9df73a1cf7a23b9f30"
         with:
           repo_token: "${{ github.token }}"
           prerelease: false

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -47,7 +47,7 @@ delete_branch_or_tag() {
 
 main() {
     # fetch history etc
-    git fetch --prune --unshallow
+    git fetch --prune --unshallow --tags
     for br in $(git ls-remote -q --heads | sed "s@^.*heads/@@"); do
         if [[ -z "$(git log --oneline -1 --since="${DATE}" origin/"${br}")" ]]; then
             branch_protected "${br}" && echo "branch: ${br} is likely protected. Won't delete it" && continue


### PR DESCRIPTION
## Description
We need to have the tags present on the repo to be able to examine
their history
