### PR TITLE
Adding a mechanism to filter per prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 # Delete Old Branches Action
 
 ## Introduction
-This simple GitHub Action will delete branches and optionally tags that haven't received a commit recently. The time since last commit is configurable
+This simple GitHub Action will delete branches and optionally tags that haven't received a commit recently. The time since last commit is configurable.
+
+The default behaviour is to exclude Github protected branches. The alternative is to provide a list of prefixes using `include_prefixes` variable. For example, setting this variable to `foo,bar,baz` will only delete the branches whose name start either by `foo`, `bar` or `baz`.
 
 ## Disclaimer
 **Always** run the GitHub action in dry-run mode to ensure that it will do the right thing before you actually let it do it. Also make sure that you have a full copy of the repository (`git clone --mirror ...`) in case something goes bad

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
     description: 'Also look for tags to delete'
     required: false
     default: false
+  include_prefixes:
+    description: 'List of branch prefixes to be deleted'
+    required: false
 
 runs:
   using: 'docker'

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -27,6 +27,19 @@ branch_protected() {
     esac
 }
 
+prefix_filter() {
+    local br=${1}
+
+    for prefix in ${INPUT_INCLUDE_PREFIXES//,/ }
+    do
+      if [[ $br = $prefix* ]]; then
+        return 1
+      fi
+    done
+
+    return 0
+}
+
 delete_branch_or_tag() {
     local br=${1} ref="${2}"
 
@@ -53,6 +66,7 @@ main() {
     for br in $(git ls-remote -q --heads | sed "s@^.*heads/@@"); do
         if [[ -z "$(git log --oneline -1 --since="${DATE}" origin/"${br}")" ]]; then
             branch_protected "${br}" && echo "branch: ${br} is likely protected. Won't delete it" && continue
+            prefix_filter "${br}" && echo "branch: ${br} won't be deleted" && continue
             delete_branch_or_tag "${br}" "heads"
         fi
     done


### PR DESCRIPTION
A change in order to include only the branches starting by a given prefix.
The change is backwards compatible. Hence, if we don't provide the include_prefix, it will still use the existing behaviour (protected branches).