### PR TITLE
Fix logic around prefixed branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Introduction
 This simple GitHub Action will delete branches and optionally tags that haven't received a commit recently. The time since last commit is configurable.
 
-The default behaviour is to exclude Github protected branches. The alternative is to provide a list of prefixes using `include_prefixes` variable. For example, setting this variable to `foo,bar,baz` will only delete the branches whose name start either by `foo`, `bar` or `baz`.
+The default behaviour is to exclude Github protected branches. Additional branches can be excluded using the `extra_protected_branch_regex` variable (see example below).
 
 ## Disclaimer
 **Always** run the GitHub action in dry-run mode to ensure that it will do the right thing before you actually let it do it. Also make sure that you have a full copy of the repository (`git clone --mirror ...`) in case something goes bad
@@ -32,6 +32,7 @@ jobs:
           date: '3 months ago'
           dry_run: true
           delete_tags: false
+          extra_protected_branch_regex: ^(foo|bar)$
 ```
 Once you are happy switch, `dry_run` to `false` so the action actually does the job
 

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,8 @@ inputs:
     description: 'Also look for tags to delete'
     required: false
     default: false
-  include_prefixes:
-    description: 'List of branch prefixes to be deleted'
+  extra_protected_branch_regex:
+    description: 'grep extended (ERE) compatible regex for additional branches to exclude'
     required: false
 
 runs:

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -11,6 +11,7 @@ DATE=${INPUT_DATE}
 GITHUB_TOKEN=${INPUT_REPO_TOKEN}
 DRY_RUN=${INPUT_DRY_RUN:-true}
 DELETE_TAGS=${INPUT_DELETE_TAGS:-false}
+EXCLUDE_BRANCH_REGEX=${INPUT_EXTRA_PROTECTED_BRANCH_REGEX:-^.*$}
 
 branch_protected() {
     local br=${1}
@@ -27,17 +28,12 @@ branch_protected() {
     esac
 }
 
-prefix_filter() {
+extra_branch_protected() {
     local br=${1}
 
-    for prefix in ${INPUT_INCLUDE_PREFIXES//,/ }
-    do
-      if [[ $br = $prefix* ]]; then
-        return 1
-      fi
-    done
+    echo "${br}" | grep -qE "${EXCLUDE_BRANCH_REGEX}"
 
-    return 0
+    return $?
 }
 
 delete_branch_or_tag() {
@@ -66,7 +62,7 @@ main() {
     for br in $(git ls-remote -q --heads | sed "s@^.*heads/@@"); do
         if [[ -z "$(git log --oneline -1 --since="${DATE}" origin/"${br}")" ]]; then
             branch_protected "${br}" && echo "branch: ${br} is likely protected. Won't delete it" && continue
-            prefix_filter "${br}" && echo "branch: ${br} won't be deleted" && continue
+            extra_branch_protected "${br}" && echo "branch: ${br} is explicitly protected and won't be deleted" && continue
             delete_branch_or_tag "${br}" "heads"
         fi
     done


### PR DESCRIPTION
The action deletes all branches by default except the protected ones.
As such, there is no reason to have a specific filter to include more
branches into this logic. What we want is a mechanism to *exclude*
branches from this logic in order to artifically protect branches which
are not marked as protected in the github API.