### PR TITLE
[delete-old-branches] Add option to keep minimum number of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ jobs:
           repo_token: ${{ github.token }}
           date: '3 months ago'
           dry_run: true
-          delete_tags: false
+          delete_tags: true
+          minimum_tags: 5
           extra_protected_branch_regex: ^(foo|bar)$
 ```
 Once you are happy switch, `dry_run` to `false` so the action actually does the job

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Also look for tags to delete'
     required: false
     default: false
+  minimum_tags:
+    descritpion: 'Minimum number of tags to keep'
+    required: false
+    default: false
   extra_protected_branch_regex:
     description: 'grep extended (ERE) compatible regex for additional branches to exclude'
     required: false

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -11,6 +11,7 @@ DATE=${INPUT_DATE}
 GITHUB_TOKEN=${INPUT_REPO_TOKEN}
 DRY_RUN=${INPUT_DRY_RUN:-true}
 DELETE_TAGS=${INPUT_DELETE_TAGS:-false}
+MINIMUM_TAGS=${INPUT_MINIMUM_TAGS:-0}
 EXCLUDE_BRANCH_REGEX=${INPUT_EXTRA_PROTECTED_BRANCH_REGEX:-^.*$}
 
 branch_protected() {
@@ -67,9 +68,15 @@ main() {
         fi
     done
     if [[ "${DELETE_TAGS}" == true ]]; then
-        for br in $(git ls-remote -q --tags --refs | sed "s@^.*tags/@@"); do
+        local tag_counter=1
+        for br in $(git ls-remote -q --tags --refs | sed "s@^.*tags/@@" | sort -rn); do
             if [[ -z "$(git log --oneline -1 --since="${DATE}" "${br}")" ]]; then
-                delete_branch_or_tag "${br}" "tags"
+                if [[ ${tag_counter} -gt ${MINIMUM_TAGS} ]]; then
+                    delete_branch_or_tag "${br}" "tags"
+                else
+                    echo "Not deleting tag ${br} due to minimum tag requirement(min: ${MINIMUM_TAGS})"
+                    ((tag_counter+=1))
+                fi
             fi
         done
     fi


### PR DESCRIPTION
Tags often correspond to actual releases so its might be desirable to
keep a minimum number of them around especially for repositories which
do not release so often otheriwse we may end up with a situation where
all the tags will be eventually deleted if nothing was committed to the
repo for X amount of time.
