### PR TITLE
Add exclude pr branch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ jobs:
           delete_tags: true
           minimum_tags: 5
           extra_protected_branch_regex: ^(foo|bar)$
+          exclude_open_pr_branches true
 ```
 Once you are happy switch, `dry_run` to `false` so the action actually does the job
 

--- a/action.yml
+++ b/action.yml
@@ -1,30 +1,33 @@
 # action.yml
-name: 'Delete old branches'
-description: 'Delete branches which are older than certain period of time'
-author: 'Markos Chandras'
+name: "Delete old branches"
+description: "Delete branches which are older than certain period of time"
+author: "Markos Chandras"
 inputs:
   repo_token:
-    description: 'The GITHUB_TOKEN secret'
+    description: "The GITHUB_TOKEN secret"
     required: true
   date:
-    description: 'A git-log compatible date format'
+    description: "A git-log compatible date format"
     required: true
   dry_run:
-    description: 'Run in dry-run mode so no branches are deleted'
+    description: "Run in dry-run mode so no branches are deleted"
     required: false
     default: true
   delete_tags:
-    description: 'Also look for tags to delete'
+    description: "Also look for tags to delete"
     required: false
     default: false
   minimum_tags:
-    descritpion: 'Minimum number of tags to keep'
+    descritpion: "Minimum number of tags to keep"
     required: false
     default: false
   extra_protected_branch_regex:
-    description: 'grep extended (ERE) compatible regex for additional branches to exclude'
+    description: "grep extended (ERE) compatible regex for additional branches to exclude"
     required: false
-
+  exclude_open_pr_branches:
+    description: "Exclude branches that have an open pull request"
+    required: false
+    default: true
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -44,7 +44,9 @@ is_pr_open_on_branch() {
     fi
 
     local br=${1}
-    open_prs_branches=$(gh pr list --state open --json headRefName | jq '.[].headRefName')
+    open_prs_branches=$(curl -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${GITHUB_TOKEN}" \
+                        "https://api.github.com/${REPO}/pulls" | jq '.[].head.ref')
+
     for pr_br in $open_prs_branches; do
         if [[ "${pr_br}" == "${br}" ]]; then
             return 0

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -13,6 +13,7 @@ DRY_RUN=${INPUT_DRY_RUN:-true}
 DELETE_TAGS=${INPUT_DELETE_TAGS:-false}
 MINIMUM_TAGS=${INPUT_MINIMUM_TAGS:-0}
 EXCLUDE_BRANCH_REGEX=${INPUT_EXTRA_PROTECTED_BRANCH_REGEX:-^$}
+EXCLUDE_OPEN_PR_BRANCHES=${INPUT_EXCLUDE_OPEN_PR_BRANCHES:-true}
 
 branch_protected() {
     local br=${1}
@@ -35,6 +36,21 @@ extra_branch_protected() {
     echo "${br}" | grep -qE "${EXCLUDE_BRANCH_REGEX}"
 
     return $?
+}
+
+is_pr_open_on_branch() {
+    if [[ "${EXCLUDE_OPEN_PR_BRANCHES}" == false ]]; then
+        return 1
+    fi
+
+    local br=${1}
+    open_prs_branches=$(gh pr list --state open --json headRefName | jq '.[].headRefName')
+    for pr_br in $open_prs_branches; do
+        if [[ "${pr_br}" == "${br}" ]]; then
+            return 0
+        fi
+    done
+    return 1
 }
 
 delete_branch_or_tag() {
@@ -64,6 +80,7 @@ main() {
         if [[ -z "$(git log --oneline -1 --since="${DATE}" origin/"${br}")" ]]; then
             branch_protected "${br}" && echo "branch: ${br} is likely protected. Won't delete it" && continue
             extra_branch_protected "${br}" && echo "branch: ${br} is explicitly protected and won't be deleted" && continue
+            is_pr_open_on_branch "${br}" && echo "branch: ${br} has an open pull request and won't be deleted" && continue
             delete_branch_or_tag "${br}" "heads"
         fi
     done


### PR DESCRIPTION
This PR adds an option to exclude branches with an open pull request

## Description
Set a flag to exclude branches with an open pull request.  Gets a list of all pull requests and checks it against branches and if there is a match the branch is excluded and not delete.  

Enabled by default, since it's probably very likely you do not want to delete a branch with an open PR.
