### PR TITLE
delete-old-branches: Protect main and master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,23 @@
-![Linting](https://github.com/beatlabs/delete-old-branches-action/workflows/Linting/badge.svg)
 # Delete Old Branches Action
 
+![Linting](https://github.com/beatlabs/delete-old-branches-action/workflows/Linting/badge.svg)
+
 ## Introduction
+
 This simple GitHub Action will delete branches and optionally tags that haven't received a commit recently. The time since last commit is configurable.
 
-The default behaviour is to exclude Github protected branches. Additional branches can be excluded using the `extra_protected_branch_regex` variable (see example below).
-Similarly, certain tags can be excluded using the `extra_protected_tag_regex` variable
+The default behaviour is to exclude the default branch (main or master) and the Github protected branches. Default branch(es) can be overriden using the `default_branches` variable (e.g. `default_branches: develop` or for multiple default branches `default_branches: main,develop,my-default-branch`).
+
+Additional branches can be excluded using the `extra_protected_branch_regex` variable (see example below).
+Similarly, certain tags can be excluded using the `extra_protected_tag_regex` variable.
 
 ## Disclaimer
+
 **Always** run the GitHub action in dry-run mode to ensure that it will do the right thing before you actually let it do it. Also make sure that you have a full copy of the repository (`git clone --mirror ...`) in case something goes bad
 
 ## Example usage
 
-```
+```yaml
 name: Cleanup old branches
 on:
   push:
@@ -37,6 +42,7 @@ jobs:
           extra_protected_branch_regex: ^(foo|bar)$
           extra_protected_tag_regex: '^v.*'
 ```
+
 Once you are happy switch, `dry_run` to `false` so the action actually does the job
 
 Happy cleaning!

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     descritpion: 'Minimum number of tags to keep'
     required: false
     default: false
+  default_branches:
+    description: 'Default branch(es) to exclude'
+    required: false
+    default: main,master
   extra_protected_branch_regex:
     description: 'grep extended (ERE) compatible regex for additional branches to exclude'
     required: false

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -12,8 +12,24 @@ GITHUB_TOKEN=${INPUT_REPO_TOKEN}
 DRY_RUN=${INPUT_DRY_RUN:-true}
 DELETE_TAGS=${INPUT_DELETE_TAGS:-false}
 MINIMUM_TAGS=${INPUT_MINIMUM_TAGS:-0}
+DEFAULT_BRANCHES=${INPUT_DEFAULT_BRANCHES:-main,master}
 EXCLUDE_BRANCH_REGEX=${INPUT_EXTRA_PROTECTED_BRANCH_REGEX:-^$}
 EXCLUDE_TAG_REGEX=${INPUT_EXTRA_PROTECTED_TAG_REGEX:-^$}
+
+default_branch_protected() {
+    local br=${1}
+
+    local default_branches
+    default_branches=$(echo "${DEFAULT_BRANCHES}" | tr "," "\n")
+
+    for default_branch in $default_branches; do
+        if [[ "${br}" == "${default_branch}" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
 
 branch_protected() {
     local br=${1}
@@ -67,6 +83,7 @@ main() {
     git fetch --prune --unshallow --tags
     for br in $(git ls-remote -q --heads --refs | sed "s@^.*heads/@@"); do
         if [[ -z "$(git log --oneline -1 --since="${DATE}" origin/"${br}")" ]]; then
+            default_branch_protected "${br}" && echo "branch: ${br} is a default branch. Won't delete it" && continue
             branch_protected "${br}" && echo "branch: ${br} is likely protected. Won't delete it" && continue
             extra_branch_or_tag_protected "${br}" "branch" && echo "branch: ${br} is explicitly protected and won't be deleted" && continue
             delete_branch_or_tag "${br}" "heads"
@@ -77,7 +94,7 @@ main() {
         for br in $(git ls-remote -q --tags --refs | sed "s@^.*tags/@@" | sort -rn); do
             if [[ -z "$(git log --oneline -1 --since="${DATE}" "${br}")" ]]; then
                 if [[ ${tag_counter} -gt ${MINIMUM_TAGS} ]]; then
-                    extra_branch_or_tag_protected "${br}" "tag" && echo "tag: ${br} is explicitely proetected and won't be deleted" && continue
+                    extra_branch_or_tag_protected "${br}" "tag" && echo "tag: ${br} is explicitly protected and won't be deleted" && continue
                     delete_branch_or_tag "${br}" "tags"
                 else
                     echo "Not deleting tag ${br} due to minimum tag requirement(min: ${MINIMUM_TAGS})"


### PR DESCRIPTION
## Description

Add main and master branches as default branches so as to be
excluded from deletion. Also, add an option for user to override the
default behavior.