### PR TITLE
delete-action-branches: Add ability to exclude certain tags pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This simple GitHub Action will delete branches and optionally tags that haven't received a commit recently. The time since last commit is configurable.
 
 The default behaviour is to exclude Github protected branches. Additional branches can be excluded using the `extra_protected_branch_regex` variable (see example below).
+Similarly, certain tags can be excluded using the `extra_protected_tag_regex` variable
 
 ## Disclaimer
 **Always** run the GitHub action in dry-run mode to ensure that it will do the right thing before you actually let it do it. Also make sure that you have a full copy of the repository (`git clone --mirror ...`) in case something goes bad
@@ -34,6 +35,7 @@ jobs:
           delete_tags: true
           minimum_tags: 5
           extra_protected_branch_regex: ^(foo|bar)$
+          extra_protected_tag_regex: '^v.*'
 ```
 Once you are happy switch, `dry_run` to `false` so the action actually does the job
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   extra_protected_branch_regex:
     description: 'grep extended (ERE) compatible regex for additional branches to exclude'
     required: false
+  extra_protected_tag_regex:
+    description: 'grep extended (ERE) compatible regex for additional tags to exclude'
+    required: false
 
 runs:
   using: 'docker'

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -13,6 +13,7 @@ DRY_RUN=${INPUT_DRY_RUN:-true}
 DELETE_TAGS=${INPUT_DELETE_TAGS:-false}
 MINIMUM_TAGS=${INPUT_MINIMUM_TAGS:-0}
 EXCLUDE_BRANCH_REGEX=${INPUT_EXTRA_PROTECTED_BRANCH_REGEX:-^$}
+EXCLUDE_TAG_REGEX=${INPUT_EXTRA_PROTECTED_TAG_REGEX:-^$}
 
 branch_protected() {
     local br=${1}
@@ -29,10 +30,14 @@ branch_protected() {
     esac
 }
 
-extra_branch_protected() {
-    local br=${1}
+extra_branch_or_tag_protected() {
+    local br=${1} ref="${2}"
 
-    echo "${br}" | grep -qE "${EXCLUDE_BRANCH_REGEX}"
+    if [[ "${ref}" == "branch" ]]; then
+        echo "${br}" | grep -qE "${EXCLUDE_BRANCH_REGEX}"
+    elif [[ "${ref}" == "tag" ]]; then
+        echo "${br}" | grep -qE "${EXCLUDE_TAG_REGEX}"
+    fi
 
     return $?
 }
@@ -63,7 +68,7 @@ main() {
     for br in $(git ls-remote -q --heads --refs | sed "s@^.*heads/@@"); do
         if [[ -z "$(git log --oneline -1 --since="${DATE}" origin/"${br}")" ]]; then
             branch_protected "${br}" && echo "branch: ${br} is likely protected. Won't delete it" && continue
-            extra_branch_protected "${br}" && echo "branch: ${br} is explicitly protected and won't be deleted" && continue
+            extra_branch_or_tag_protected "${br}" "branch" && echo "branch: ${br} is explicitly protected and won't be deleted" && continue
             delete_branch_or_tag "${br}" "heads"
         fi
     done
@@ -72,6 +77,7 @@ main() {
         for br in $(git ls-remote -q --tags --refs | sed "s@^.*tags/@@" | sort -rn); do
             if [[ -z "$(git log --oneline -1 --since="${DATE}" "${br}")" ]]; then
                 if [[ ${tag_counter} -gt ${MINIMUM_TAGS} ]]; then
+                    extra_branch_or_tag_protected "${br}" "tag" && echo "tag: ${br} is explicitely proetected and won't be deleted" && continue
                     delete_branch_or_tag "${br}" "tags"
                 else
                     echo "Not deleting tag ${br} due to minimum tag requirement(min: ${MINIMUM_TAGS})"


### PR DESCRIPTION
There might be cases where certain tags need to be excluded from
deletion. As such, lets add the ability to do that similarly to how
excluded branches are handled.
