### PR TITLE
Add exclude pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The default behaviour is to exclude the default branch (main or master) and the 
 
 Additional branches can be excluded using the `extra_protected_branch_regex` variable (see example below).
 Similarly, certain tags can be excluded using the `extra_protected_tag_regex` variable.
+Also, branches with open pull requests are being ignored by default (see example below).  
 
 ## Disclaimer
 
@@ -41,6 +42,7 @@ jobs:
           minimum_tags: 5
           extra_protected_branch_regex: ^(foo|bar)$
           extra_protected_tag_regex: '^v.*'
+          exclude_open_pr_branches: true
 ```
 
 Once you are happy switch, `dry_run` to `false` so the action actually does the job

--- a/action.yml
+++ b/action.yml
@@ -1,37 +1,40 @@
 # action.yml
-name: 'Delete old branches'
-description: 'Delete branches which are older than certain period of time'
-author: 'Markos Chandras'
+name: "Delete old branches"
+description: "Delete branches which are older than certain period of time"
+author: "Markos Chandras"
 inputs:
   repo_token:
-    description: 'The GITHUB_TOKEN secret'
+    description: "The GITHUB_TOKEN secret"
     required: true
   date:
-    description: 'A git-log compatible date format'
+    description: "A git-log compatible date format"
     required: true
   dry_run:
-    description: 'Run in dry-run mode so no branches are deleted'
+    description: "Run in dry-run mode so no branches are deleted"
     required: false
     default: true
   delete_tags:
-    description: 'Also look for tags to delete'
+    description: "Also look for tags to delete"
     required: false
     default: false
   minimum_tags:
-    descritpion: 'Minimum number of tags to keep'
+    descritpion: "Minimum number of tags to keep"
     required: false
     default: false
   default_branches:
-    description: 'Default branch(es) to exclude'
+    description: "Default branch(es) to exclude"
     required: false
     default: main,master
   extra_protected_branch_regex:
-    description: 'grep extended (ERE) compatible regex for additional branches to exclude'
+    description: "grep extended (ERE) compatible regex for additional branches to exclude"
     required: false
   extra_protected_tag_regex:
-    description: 'grep extended (ERE) compatible regex for additional tags to exclude'
+    description: "grep extended (ERE) compatible regex for additional tags to exclude"
     required: false
-
+  exclude_open_pr_branches:
+    description: "Exclude branches that have an open pull request"
+    required: false
+    default: true
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -15,6 +15,7 @@ MINIMUM_TAGS=${INPUT_MINIMUM_TAGS:-0}
 DEFAULT_BRANCHES=${INPUT_DEFAULT_BRANCHES:-main,master}
 EXCLUDE_BRANCH_REGEX=${INPUT_EXTRA_PROTECTED_BRANCH_REGEX:-^$}
 EXCLUDE_TAG_REGEX=${INPUT_EXTRA_PROTECTED_TAG_REGEX:-^$}
+EXCLUDE_OPEN_PR_BRANCHES=${INPUT_EXCLUDE_OPEN_PR_BRANCHES:-true}
 
 default_branch_protected() {
     local br=${1}
@@ -58,6 +59,24 @@ extra_branch_or_tag_protected() {
     return $?
 }
 
+is_pr_open_on_branch() {
+    if [[ "${EXCLUDE_OPEN_PR_BRANCHES}" == false ]]; then
+        return 1
+    fi
+
+    local br=${1}
+    open_prs_branches=$(curl -X GET -s -H "Authorization: token ${GITHUB_TOKEN}" \
+        "${BASE_URI}/repos/${REPO}/pulls" | jq '.[].head.ref' | tr -d '"')
+
+    for pr_br in ${open_prs_branches}; do
+      if [[ "${pr_br}" == "${br}" ]]; then
+          return 0
+      fi
+    done
+
+    return 1
+}
+
 delete_branch_or_tag() {
     local br=${1} ref="${2}"
 
@@ -86,6 +105,7 @@ main() {
             default_branch_protected "${br}" && echo "branch: ${br} is a default branch. Won't delete it" && continue
             branch_protected "${br}" && echo "branch: ${br} is likely protected. Won't delete it" && continue
             extra_branch_or_tag_protected "${br}" "branch" && echo "branch: ${br} is explicitly protected and won't be deleted" && continue
+            is_pr_open_on_branch "${br}" && echo "branch: ${br} has an open pull request and won't be deleted" && continue
             delete_branch_or_tag "${br}" "heads"
         fi
     done


### PR DESCRIPTION
Exclude branches with an open pull request
## Description
Excludes source branches with a pull request. 
This will be the default behavior as it is probably not prudent to delete branches with an open pull request.
However this can be easily overridden by setting "exclude_open_pr_branches" to false.
