### PR TITLE
Include action output values - `was_dry_run` and `deleted_branches`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,11 @@ inputs:
     description: "Exclude branches that have an open pull request"
     required: false
     default: true
+outputs:
+  was_dry_run:
+    description: "Ran in dry-run mode so no branches were deleted"
+  deleted_branches:
+    description: "List of branches that were deleted"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -113,7 +113,7 @@ main() {
             delete_branch_or_tag "${br}" "heads"
         fi
     done
-    echo "::set-output name=deleted_branches::${deleted_branches[@]}"
+    echo "::set-output name=deleted_branches::" "${deleted_branches[@]}"
     if [[ "${DELETE_TAGS}" == true ]]; then
         local tag_counter=1
         for br in $(git ls-remote -q --tags --refs | sed "s@^.*tags/@@" | sort -rn); do

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -17,6 +17,9 @@ EXCLUDE_BRANCH_REGEX=${INPUT_EXTRA_PROTECTED_BRANCH_REGEX:-^$}
 EXCLUDE_TAG_REGEX=${INPUT_EXTRA_PROTECTED_TAG_REGEX:-^$}
 EXCLUDE_OPEN_PR_BRANCHES=${INPUT_EXCLUDE_OPEN_PR_BRANCHES:-true}
 
+echo "::set-output name=was_dry_run::${DRY_RUN}"
+deleted_branches=()
+
 default_branch_protected() {
     local br=${1}
 
@@ -79,6 +82,7 @@ is_pr_open_on_branch() {
 
 delete_branch_or_tag() {
     local br=${1} ref="${2}"
+    deleted_branches+=("${br}")
 
     echo "Deleting: ${br}"
     if [[ "${DRY_RUN}" == false ]]; then
@@ -109,6 +113,7 @@ main() {
             delete_branch_or_tag "${br}" "heads"
         fi
     done
+    echo "::set-output name=deleted_branches::${deleted_branches[@]}"
     if [[ "${DELETE_TAGS}" == true ]]; then
         local tag_counter=1
         for br in $(git ls-remote -q --tags --refs | sed "s@^.*tags/@@" | sort -rn); do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

GitHub actions can take inputs and also provide outputs.

Added some output params so that downstream steps can use the output from this action.

- `was_dry_run`
- `deleted_branches`

Example Usage:
```yml
jobs:
  delete_old_branches:
    name: Delete old git branches
    runs-on: ubuntu-latest
    steps:
      - name: Run delete-old-branches action
        id: delete_branches
        uses: beatlabs/delete-old-branches-action@v0.0.8
        with:
          repo_token: ${{ github.token }}
          date: '3 months ago'
          dry_run: true

      - name: Slack Notification
        uses: archive/github-actions-slack@v2.4.0
        with:
          slack-bot-user-oauth-access-token: ...
          slack-channel: ...
          slack-text: |
            *The following branches were deleted:*
            ${{steps.delete_branches.outputs.delete_branches}}
            Dry Run?: ${{steps.delete_branches.outputs.was_dry_run}}
```

More info about output with Docker are in the github docs here: https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action#creating-an-action-metadata-file