### PR TITLE
Updated Deprecations in Github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run delete-old-branches-action
-        uses: beatlabs/delete-old-branches-action@v0.0.9
+        uses: beatlabs/delete-old-branches-action@v0.1.0
         with:
           repo_token: ${{ github.token }}
           date: '3 months ago'

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -17,7 +17,7 @@ EXCLUDE_BRANCH_REGEX=${INPUT_EXTRA_PROTECTED_BRANCH_REGEX:-^$}
 EXCLUDE_TAG_REGEX=${INPUT_EXTRA_PROTECTED_TAG_REGEX:-^$}
 EXCLUDE_OPEN_PR_BRANCHES=${INPUT_EXCLUDE_OPEN_PR_BRANCHES:-true}
 
-echo "::set-output name=was_dry_run::${DRY_RUN}"
+echo "::save-state name=was_dry_run::${DRY_RUN}"
 deleted_branches=()
 
 default_branch_protected() {
@@ -117,7 +117,7 @@ main() {
             delete_branch_or_tag "${br}" "heads" "${sha}"
         fi
     done
-    echo "::set-output name=deleted_branches::" "${deleted_branches[@]}"
+    echo "::save-state name=deleted_branches::" "${deleted_branches[@]}"
     if [[ "${DELETE_TAGS}" == true ]]; then
         local tag_counter=1
         for br in $(git ls-remote -q --tags --refs | sed "s@^.*tags/@@" | sort -rn); do


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!--- Provide a general summary of your changes in the Title above -->
## Description
Deprecations to set-output to save-state
Deprecations to Using versioned actions
<!--- Describe your changes in detail -->

#### Related Issues
<!--- Does this relate to any issues? -->
Addresses # Updated Deprecations
