### PR TITLE
fix: retrieve all branches through pagination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 LABEL maintainer="markos@chandras.me"
 
-RUN apk add --no-cache bash ca-certificates curl git jq
+RUN apk add --no-cache bash ca-certificates git github-cli
 
 COPY delete-old-branches /usr/bin/delete-old-branches
 

--- a/delete-old-branches
+++ b/delete-old-branches
@@ -5,10 +5,8 @@ set -eo pipefail
 [[ -n ${INPUT_REPO_TOKEN} ]] || { echo "Please set the REPO_TOKEN input"; exit 1; }
 [[ -n ${INPUT_DATE} ]] || { echo "Please specify a suitable date input for branch filtering"; exit 1; }
 
-BASE_URI="https://api.github.com"
 REPO="${GITHUB_REPOSITORY}"
 DATE=${INPUT_DATE}
-GITHUB_TOKEN=${INPUT_REPO_TOKEN}
 DRY_RUN=${INPUT_DRY_RUN:-true}
 DELETE_TAGS=${INPUT_DELETE_TAGS:-false}
 MINIMUM_TAGS=${INPUT_MINIMUM_TAGS:-0}
@@ -16,6 +14,9 @@ DEFAULT_BRANCHES=${INPUT_DEFAULT_BRANCHES:-main,master}
 EXCLUDE_BRANCH_REGEX=${INPUT_EXTRA_PROTECTED_BRANCH_REGEX:-^$}
 EXCLUDE_TAG_REGEX=${INPUT_EXTRA_PROTECTED_TAG_REGEX:-^$}
 EXCLUDE_OPEN_PR_BRANCHES=${INPUT_EXCLUDE_OPEN_PR_BRANCHES:-true}
+
+# used for GitHub CLI authentication
+export GITHUB_TOKEN=${INPUT_REPO_TOKEN}
 
 echo "was_dry_run=${DRY_RUN}"  >> $GITHUB_OUTPUT
 deleted_branches=()
@@ -38,8 +39,7 @@ default_branch_protected() {
 branch_protected() {
     local br=${1}
 
-    protected=$(curl -X GET -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-        "${BASE_URI}/repos/${REPO}/branches/${br}" | jq -r .protected)
+    protected=$(gh api "repos/${REPO}/branches/${br}" --jq '.protected')
 
     # If we got null then something else happened (like no access error etc) so
     # we can't determine the status for the branch
@@ -68,8 +68,7 @@ is_pr_open_on_branch() {
     fi
 
     local br=${1}
-    open_prs_branches=$(curl -X GET -s -H "Authorization: token ${GITHUB_TOKEN}" \
-        "${BASE_URI}/repos/${REPO}/pulls" | jq '.[].head.ref' | tr -d '"')
+    open_prs_branches=$(gh api "repos/${REPO}/pulls" --jq '.[].head.ref' --paginate)
 
     for pr_br in ${open_prs_branches}; do
       if [[ "${pr_br}" == "${br}" ]]; then
@@ -87,13 +86,12 @@ delete_branch_or_tag() {
     echo "Deleting: ${br}"
     echo "To recreate run: git branch '${br}' '${sha}'"
     if [[ "${DRY_RUN}" == false ]]; then
-        status=$(curl -I -X DELETE -o debug.log -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                    -w "%{http_code}" "${BASE_URI}/repos/${REPO}/git/refs/${ref}/${br}")
+        status=$(gh api --method DELETE "repos/${REPO}/git/refs/${ref}/${br}" &> debug.log && echo ok || echo failed)
 
         case ${status} in
-            204) ;;
+            ok) ;;
             *)  echo "Deletion of branch ${br} failed with http_status=${status}"
-                echo "===== Dumping curl call ====="
+                echo "===== Dumping log ====="
                 [[ -f debug.log ]] && cat debug.log
                 ;;
         esac


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Currently, only the 30th first opened pull requests are fetched by the curl API call ([docs](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests)). To avoid dealing with [header links for pagination](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28) let's use the GitHub CLI (`gh`) with the `--paginate` flag.

And since it doesn't make sense to mix `curl` and `gh api`, lets replace all `curl` occurrences by the way.

#### Related Issues
<!--- Does this relate to any issues? -->
Ø
