### PR TITLE
Sort tags via semver to preserve newest tags

### DIFF
--- a/delete-old-branches
+++ b/delete-old-branches
@@ -119,7 +119,7 @@ main() {
     echo "deleted_branches=${deleted_branches[*]}" >> "$GITHUB_OUTPUT"
     if [[ "${DELETE_TAGS}" == true ]]; then
         local tag_counter=1
-        for br in $(git ls-remote -q --tags --refs | sed "s@^.*tags/@@" | sort -rn); do
+        for br in $(git ls-remote -q --tags --refs | sed "s@^.*tags/@@" | sort -Vr); do
             if [[ -z "$(git log --oneline -1 --since="${DATE}" "${br}")" ]]; then
                 if [[ ${tag_counter} -gt ${MINIMUM_TAGS} ]]; then
                     extra_branch_or_tag_protected "${br}" "tag" && echo "tag: ${br} is explicitly protected and won't be deleted" && continue


### PR DESCRIPTION
## Description
I want to have the  minimum_tags field save the latest tags according to semver, not numerically.  I ran this command and this is the output which is desired:

```bash
git ls-remote -q --tags --refs | sed "s@^.*tags/@@" | sort -Vr
release-0.24.1
release-0.24.0
release-0.23.5
release-0.23.4
release-0.23.3
release-0.23.2
release-0.23.1
release-0.23.0
0.24.1
0.24.0
0.23.5
0.23.4
0.23.3
0.23.2
0.23.1
0.23.0
```

#### Related Issues
none

